### PR TITLE
Julia 0.5 update + precompile

### DIFF
--- a/src/Elliptic.jl
+++ b/src/Elliptic.jl
@@ -1,5 +1,6 @@
-module Elliptic
+__precompile__()
 
+module Elliptic
 # elliptic integrals of 1st/2nd/3rd kind
 export E, F, K, Pi
 

--- a/src/jacobi.jl
+++ b/src/jacobi.jl
@@ -73,7 +73,7 @@ end
 xn = ((:s,:(sn(u,m))), (:c,:(cn(u,m))), (:d,:(dn(u,m))), (:n,:(1.)))
 for (p,num) in xn, (q,den) in xn
     if p == q continue end
-    f = symbol(string(p,q))
+    f = Symbol(string(p,q))
     if q != :n
         @eval ($f)(u::Float64, m::Float64) = ($num)/($den)
     end


### PR DESCRIPTION
Tiny change to make on deprecation warning go away (no `@compat` needed).  + precompile.  Tests pass on my machine for both Julia 0.4 and 0.5.
