### PR TITLE
extend domain to negative m

### DIFF
--- a/src/Elliptic.jl
+++ b/src/Elliptic.jl
@@ -13,7 +13,7 @@ include("slatec.jl")
 
 function E(phi::Float64, m::Float64)
     if isnan(phi) || isnan(m) return NaN end
-    if m > 1. throw(DomainError()) end
+    if m < 0. || m > 1. throw(DomainError()) end
     if abs(phi) > pi/2
         phi2 = phi + pi/2
         return 2*fld(phi2,pi)*E(m) - _E(cos(mod(phi2,pi)), m)
@@ -75,7 +75,7 @@ F(phi::Real, m::Real) = F(Float64(phi), Float64(m))
 
 function K(m::Float64)
     if isnan(m) return NaN end
-    if m < 0. || m > 1. throw(DomainError()) end
+    if m > 1. throw(DomainError()) end
     if m == 1. return Inf end
     drf,ierr = SLATEC.DRF(0., 1. - m, 1.)
     @assert ierr == 0

--- a/src/Elliptic.jl
+++ b/src/Elliptic.jl
@@ -13,7 +13,7 @@ include("slatec.jl")
 
 function E(phi::Float64, m::Float64)
     if isnan(phi) || isnan(m) return NaN end
-    if m < 0. || m > 1. throw(DomainError()) end
+    if m > 1. throw(DomainError()) end
     if abs(phi) > pi/2
         phi2 = phi + pi/2
         return 2*fld(phi2,pi)*E(m) - _E(cos(mod(phi2,pi)), m)


### PR DESCRIPTION
I encountered a problem in computing complete elliptic integrals for negative values of m while I was working on my PhD project. The function K(m) can be actually computed also for m<0. This is equivalent to the so-called 'imaginary modulus transformation' for this kind of integrals (http://analyticphysics.com/Mathematical%20Methods/A%20Miscellany%20of%20Elliptic%20Integrals.htm):
K(-m)=(1/\sqrt(1+m))K(m/m+1)
In this way, K(m) is well-defined for -\infty<m<1. 
I simply removed the if condition on 'm<0': the routine computes the correct values of the integral for negative m (I compared it to the mathematica implementation of this function and numerical integration).
I expect the same problem to hold also for the incomplete integral F(\phi,m).