### PR TITLE
Make elliptic integrals differentiable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "Elliptic"
-uuid = "b305315f-e792-5b7a-8f41-49f472929428"
+uuid = "0849f792-3ea3-11ed-3c0b-7b4bcacd782f"
 keywords = ["elliptic", "integral", "Jacobi", "special functions"]
 license = "MIT"
 desc = "Elliptic integrals and Jacobi elliptic special functions"
-author = ["Mike Nolta <mike@nolta.net>"]
-version = "1.0.1"
+author = ["Mike Nolta <mike@nolta.net> and contributors"]
+version = "1.0.2"
 
 [compat]
 julia = "1"

--- a/src/Elliptic.jl
+++ b/src/Elliptic.jl
@@ -11,7 +11,7 @@ export ellipj, ellipke
 include("jacobi.jl")
 include("slatec.jl")
 
-function E(phi::Float64, m::Float64)
+function E(phi, m)
     if isnan(phi) || isnan(m) return NaN end
     if m < 0. || m > 1. throw(DomainError(m, "argument m not in [0,1]")) end
     if abs(phi) > pi/2
@@ -20,7 +20,7 @@ function E(phi::Float64, m::Float64)
     end
     _E(sin(phi), m)
 end
-function _E(sinphi::Float64, m::Float64)
+function _E(sinphi, m)
     sinphi2 = sinphi^2
     cosphi2 = 1. - sinphi2
     y = 1. - m*sinphi2
@@ -34,14 +34,12 @@ function _E(sinphi::Float64, m::Float64)
     end
     NaN
 end
-E(phi::Real, m::Real) = E(Float64(phi), Float64(m))
-
 
 """
 `ellipke(m::Real)`
 returns `(K(m), E(m))` for scalar `0 ≤ m ≤ 1`
 """
-function ellipke(m::Float64)
+function ellipke(m)
     if m < 1.
         y = 1. - m
         drf,ierr1 = SLATEC.DRF(0., y, 1.)
@@ -56,14 +54,11 @@ function ellipke(m::Float64)
         throw(DomainError(m, "argument m not <= 1"))
     end
 end
-ellipke(x::Real) = ellipke(Float64(x))
 
 E(m::Float64) = ellipke(m)[2]
-E(x::Float32) = Float32(E(Float64(x)))
-E(x::Real) = E(Float64(x))
 
 # assumes 0 ≤ m ≤ 1
-function rawF(sinphi::Float64, m::Float64)
+function rawF(sinphi, m)
     if abs(sinphi) == 1. && m == 1. return sign(sinphi)*Inf end
     sinphi2 = sinphi^2
     drf,ierr = SLATEC.DRF(1. - sinphi2, 1. - m*sinphi2, 1.)
@@ -71,7 +66,7 @@ function rawF(sinphi::Float64, m::Float64)
     sinphi*drf
 end
 
-function F(phi::Float64, m::Float64)
+function F(phi, m)
     if isnan(phi) || isnan(m) return NaN end
     if m < 0. || m > 1. throw(DomainError(m, "argument m not in [0,1]")) end
     if abs(phi) > pi/2
@@ -81,9 +76,8 @@ function F(phi::Float64, m::Float64)
     end
     rawF(sin(phi), m)
 end
-F(phi::Real, m::Real) = F(Float64(phi), Float64(m))
 
-function K(m::Float64)
+function K(m)
     if m < 1.
         drf,ierr = SLATEC.DRF(0., 1. - m, 1.)
         @assert ierr == 0
@@ -96,10 +90,8 @@ function K(m::Float64)
         throw(DomainError(m, "argument m not <= 1"))
     end
 end
-K(x::Float32) = Float32(K(Float64(x)))
-K(x::Real) = K(Float64(x))
 
-function Pi(n::Float64, phi::Float64, m::Float64)
+function Pi(n, phi, m)
     if isnan(n) || isnan(phi) || isnan(m) return NaN end
     if m < 0. || m > 1. throw(DomainError(m, "argument m not in [0,1]")) end
     sinphi = sin(phi)
@@ -119,17 +111,15 @@ function Pi(n::Float64, phi::Float64, m::Float64)
     end
     NaN
 end
-Pi(n::Real, phi::Real, m::Real) = Pi(Float64(n), Float64(phi), Float64(m))
 Π = Pi
 
-function ellipj(u::Float64, m::Float64, tol::Float64)
+function ellipj(u, m, tol)
     phi = Jacobi.am(u, m, tol)
     s = sin(phi)
     c = cos(phi)
     d = sqrt(1. - m*s^2)
     s, c, d
 end
-ellipj(u::Float64, m::Float64) = ellipj(u, m, eps(Float64))
-ellipj(u::Real, m::Real) = ellipj(Float64(u), Float64(m))
+ellipj(u, m) = ellipj(u, m, eps(Float64))
 
 end # module

--- a/src/Elliptic.jl
+++ b/src/Elliptic.jl
@@ -55,7 +55,7 @@ function ellipke(m)
     end
 end
 
-E(m::Float64) = ellipke(m)[2]
+E(m) = ellipke(m)[2]
 
 # assumes 0 ≤ m ≤ 1
 function rawF(sinphi, m)

--- a/src/slatec.jl
+++ b/src/slatec.jl
@@ -33,7 +33,7 @@ const D1MACH5 = log10(2.)
 #             Lawrence Livermore National Laboratory
 #             Livermore, CA  94550
 
-function DRF(X::Float64, Y::Float64, Z::Float64)
+function DRF(X, Y, Z)
 
     ERRTOL = (4.0*D1MACH3)^(1.0/6.0)
     LOLIM  = 5.0 * D1MACH1
@@ -112,7 +112,7 @@ end
 #             Lawrence Livermore National Laboratory
 #             Livermore, CA  94550
 
-function DRD(X::Float64, Y::Float64, Z::Float64)
+function DRD(X, Y, Z)
 
     ERRTOL = (D1MACH3/3.0)^(1.0/6.0)
     LOLIM  = 2.0/(D1MACH2)^(2.0/3.0)
@@ -200,7 +200,7 @@ end
 #             Lawrence Livermore National Laboratory
 #             Livermore, CA  94550
 
-function DRC(X::Float64, Y::Float64)
+function DRC(X, Y)
 
     ERRTOL = (D1MACH3/16.0)^(1.0/6.0)
     LOLIM  = 5.0 * D1MACH1
@@ -266,7 +266,7 @@ end
 #             Lawrence Livermore National Laboratory
 #             Livermore, CA  94550
 
-function DRJ(X::Float64, Y::Float64, Z::Float64, P::Float64)
+function DRJ(X, Y, Z, P)
 
     ERRTOL = (D1MACH3/3.0)^(1.0/6.0)
     LOLIM  = (5.0 * D1MACH1)^(1.0/3.0)

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,0 +1,387 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[AbstractFFTs]]
+deps = ["ChainRulesCore", "LinearAlgebra"]
+git-tree-sha1 = "69f7020bd72f069c219b5e8c236c1fa90d2cb409"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.2.1"
+
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.4.0"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CEnum]]
+git-tree-sha1 = "eb4cb44a499229b3b8426dcfb5dd85333951ff90"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.4.2"
+
+[[ChainRules]]
+deps = ["Adapt", "ChainRulesCore", "Compat", "Distributed", "GPUArraysCore", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics", "StructArrays"]
+git-tree-sha1 = "a5fd229d3569a6600ae47abe8cd48cbeb972e173"
+uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+version = "1.44.6"
+
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "dc4405cee4b2fe9e1108caec2d760b7ea758eca2"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.15.5"
+
+[[ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "38f7a08f19d8810338d4f5085211c7dfa5d5bdd8"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.4"
+
+[[CommonSubexpressions]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.0"
+
+[[Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "5856d3031cdb1f3b2b6340dfdc66b6d9a149a374"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.2.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[DataAPI]]
+git-tree-sha1 = "fb5f5316dd3fd4c5e7c30a24d50643b73e37cd40"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.10.0"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DiffResults]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.0.3"
+
+[[DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "992a23afdb109d0d2f8802a30cf5ae4b1fe7ea68"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.11.1"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "5158c2b41018c5f7eb1470d558127ac274eca0c9"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.1"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "87519eb762f85534445f5cda35be12e32759ee14"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.13.4"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "187198a4ed8ccd7b5d99c41b69c679269ea2b2d4"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.32"
+
+[[GPUArrays]]
+deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
+git-tree-sha1 = "45d7deaf05cbb44116ba785d147c518ab46352d7"
+uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+version = "8.5.0"
+
+[[GPUArraysCore]]
+deps = ["Adapt"]
+git-tree-sha1 = "6872f5ec8fd1a38880f027a26739d42dcda6691f"
+uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
+version = "0.1.2"
+
+[[IRTools]]
+deps = ["InteractiveUtils", "MacroTools", "Test"]
+git-tree-sha1 = "af14a478780ca78d5eb9908b263023096c2b9d64"
+uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
+version = "0.4.6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "b3364212fb5d870f724876ffcd34dd8ec6d98918"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.7"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
+[[LLVM]]
+deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
+git-tree-sha1 = "e7e9184b0bf0158ac4e4aa9daf00041b5909bf1a"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "4.14.0"
+
+[[LLVMExtra_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
+git-tree-sha1 = "771bfe376249626d3ca12bcd58ba243d3f961576"
+uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+version = "0.0.16+0"
+
+[[LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "94d9c52ca447e23eac0c0f074effbcd38830deb5"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.18"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.9"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "a7c3d1da1189a1c2fe843a3bfa04d18d20eb3211"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.0.1"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.3.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RealDot]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "9f0a1b71baaf7650f4fa8a1d168c7fb6ee41f0c9"
+uuid = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
+version = "0.1.0"
+
+[[Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "d75bda01f8c31ebb72df80a46c88b25d1c79c56d"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.1.7"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "dfec37b90740e3b9aa5dc2613892a3fc155c3b42"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.5.6"
+
+[[StaticArraysCore]]
+git-tree-sha1 = "ec2bd695e905a3c755b33026954b119ea17f2d22"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.3.0"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "StaticArraysCore", "Tables"]
+git-tree-sha1 = "8c6ac65ec9ab781af05b08ff305ddc727c25f680"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.6.12"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits", "Test"]
+git-tree-sha1 = "5ce79ce186cc678bbb5c5681ca3379d1ddae11a1"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.7.0"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[Zygote]]
+deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "GPUArrays", "GPUArraysCore", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
+git-tree-sha1 = "c3f4af6b167f0c181148650221a4cbabf6bbb8a6"
+uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
+version = "0.6.47"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "8c1a8e4dfacb1fd631745552c8db35d0deb09ea0"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.2"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -49,12 +49,5 @@ using SpecialFunctions
         @test Zygote.gradient(m -> E(ϕ, m), m)[1] ≈ (E(ϕ, m) - F(ϕ, m)) / 2m
         @test ForwardDiff.derivative(m -> E(ϕ, m), m) ≈ (E(ϕ, m) - F(ϕ, m)) / 2m
 
-        # 7. ∂n(Π(n, ϕ, m)) == inv(2 * (m-n) * (n-1)) * (E(ϕ, m) + (m - n)/n * F(ϕ, m) + (n^2 - m)/n * Elliptic.Pi(n, ϕ, m) - n * sqrt(1 - m * sin(ϕ)^2) * sin(2ϕ) / 2 / (1 - n * sin(ϕ)^2))
-        #@test Zygote.gradient(n -> Elliptic.Pi(n, ϕ, m), n)[1] ≈ inv(2 * (m-n) * (n-1)) * (E(ϕ, m) + (m - n)/n * F(ϕ, m) + (n^2 - m)/n * Elliptic.Pi(n, ϕ, m) - n * √(1 - m * sin(ϕ)^2) * sin(2ϕ) / 2 / (1 - n * sin(ϕ)^2))
-
-        # 7. ∂ϕ(Π(n, ϕ, m)) == 1 / (√(1 - m*sin(ϕ)^2) * (1 - n * sin(ϕ)^2))
-
-        # 8. ∂m(Π(ϕ, m)) == (E(ϕ, m) / (m - 1) + Π(n, ϕ, m) - m*sin(2ϕ) / (2 * (m-1) * √(1 - m * sin(ϕ)^2))) / (2 * (n-m))
-
     end
 end

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -1,0 +1,60 @@
+using Zygote
+using ForwardDiff
+using SpecialFunctions
+
+@testset "Zygote and ForwardDiff" begin
+
+    num_trials = 1
+    ks = rand(num_trials)
+    ϕs = rand(num_trials) .* 2π
+    ns = rand(num_trials)
+
+    @show ks, ϕs, ns
+
+    # Test several known derivative identities across a wide range of values of ϕ and m
+    # in order to verify that derivatives work correctly
+    for (k, ϕ, n) in zip(ks, ϕs, ns)
+        m = k^2
+        dk_dm = 0.5 / k
+
+        # I. Tests for complete integrals, from https://en.wikipedia.org/wiki/Elliptic_integral
+        # 1. K'(m) == K'(k) * dk/dm == E(k) / (k * (1 - k^2)) - K(k)/k
+        @test Zygote.gradient(K, m)[1] ≈ (E(m) / (k * (1 - k^2)) - K(m) / k) * dk_dm
+        @test ForwardDiff.derivative(K, m) ≈ (E(m) / (k * (1 - k^2)) - K(m) / k) * dk_dm
+
+        # 2. E'(m) == E'(k) * dk/dm == (E(k) - K(k))/k
+        @test Zygote.gradient(E, m)[1] ≈ (E(m) - K(m))/k * dk_dm
+        @test ForwardDiff.derivative(E, m) ≈ (E(m) - K(m))/k * dk_dm
+
+        # II. Tests for incomplete integrals, from https://functions.wolfram.com/EllipticIntegrals/EllipticF/introductions/IncompleteEllipticIntegrals/ShowAll.html
+        # 3. ∂ϕ(F(ϕ, m)) == 1 / √(1 - m*sin(ϕ)^2)
+        @test Zygote.gradient(ϕ -> F(ϕ, m), ϕ)[1] ≈ 1 / √(1 - m*sin(ϕ)^2)
+        @test ForwardDiff.derivative(ϕ -> F(ϕ, m), ϕ) ≈ 1 / √(1 - m*sin(ϕ)^2)
+
+        # 4. ∂m(F(ϕ, m)) == E(ϕ, m) / (2 * m * (1 - m)) - F(ϕ, m) / 2m - sin(2ϕ) / (4 * (1-m) * √(1 - m * sin(ϕ)^2))
+        @test Zygote.gradient(m -> F(ϕ, m), m)[1] ≈
+            E(ϕ, m) / (2 * m * (1 - m)) -
+            F(ϕ, m) / 2 / m -
+            sin(2*ϕ) / (4 * (1 - m) * √(1 - m * sin(ϕ)^2))
+        @test ForwardDiff.derivative(m -> F(ϕ, m), m) ≈
+            E(ϕ, m) / (2 * m * (1 - m)) -
+            F(ϕ, m) / 2 / m -
+            sin(2*ϕ) / (4 * (1 - m) * √(1 - m * sin(ϕ)^2))
+
+        # 5. ∂ϕ(E(ϕ, m)) == √(1 - m * sin(ϕ)^2)
+        @test Zygote.gradient(ϕ -> E(ϕ, m), ϕ)[1] ≈ √(1 - m * sin(ϕ)^2)
+        @test ForwardDiff.derivative(ϕ -> E(ϕ, m), ϕ) ≈ √(1 - m * sin(ϕ)^2)
+
+        # 6. ∂m(E(ϕ, m)) == (E(ϕ, m) - F(ϕ, m)) / 2m
+        @test Zygote.gradient(m -> E(ϕ, m), m)[1] ≈ (E(ϕ, m) - F(ϕ, m)) / 2m
+        @test ForwardDiff.derivative(m -> E(ϕ, m), m) ≈ (E(ϕ, m) - F(ϕ, m)) / 2m
+
+        # 7. ∂n(Π(n, ϕ, m)) == inv(2 * (m-n) * (n-1)) * (E(ϕ, m) + (m - n)/n * F(ϕ, m) + (n^2 - m)/n * Elliptic.Pi(n, ϕ, m) - n * sqrt(1 - m * sin(ϕ)^2) * sin(2ϕ) / 2 / (1 - n * sin(ϕ)^2))
+        #@test Zygote.gradient(n -> Elliptic.Pi(n, ϕ, m), n)[1] ≈ inv(2 * (m-n) * (n-1)) * (E(ϕ, m) + (m - n)/n * F(ϕ, m) + (n^2 - m)/n * Elliptic.Pi(n, ϕ, m) - n * √(1 - m * sin(ϕ)^2) * sin(2ϕ) / 2 / (1 - n * sin(ϕ)^2))
+
+        # 7. ∂ϕ(Π(n, ϕ, m)) == 1 / (√(1 - m*sin(ϕ)^2) * (1 - n * sin(ϕ)^2))
+
+        # 8. ∂m(Π(ϕ, m)) == (E(ϕ, m) / (m - 1) + Π(n, ϕ, m) - m*sin(2ϕ) / (2 * (m-1) * √(1 - m * sin(ϕ)^2))) / (2 * (n-m))
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using SpecialFunctions: gamma
 using Elliptic
 using DelimitedFiles: readdlm
 
+include("autodiff.jl")
+
 @testset "NaNs" begin
     @test E(NaN) === NaN
     @test K(NaN) === NaN


### PR DESCRIPTION
This PR addresses https://github.com/nolta/Elliptic.jl/issues/28 by removing all type annotations for the elliptic integrals so that they are auto-differentiable. I have checked using Zygote.jl and ForwardDiff.jl and have added a suite of tests to verify several elliptic integral differentiation identities.


